### PR TITLE
[render preview] side bar and map issues fix

### DIFF
--- a/src/components.py
+++ b/src/components.py
@@ -12,6 +12,10 @@ if "RENDER" in os.environ:
 else:
     from data import *
 
+def truncate_text(text, max_length=25):
+    """Truncate text to max_length and add '...' if it's longer"""
+    return text if len(text) <= max_length else text[:max_length] + "..."
+
 header = html.Div([
     html.H1("CAN-US Trade Relations Dashboard", className="text-center", 
             style={"color": "white", "padding": "15px"})
@@ -24,6 +28,7 @@ sidebar = dbc.Col([
         id="province-dropdown",
         options=[{"label": geo, "value": geo} for geo in unique_provinces],
         value="Canada",
+        clearable=False, 
         className="mb-3"
     ),
 
@@ -32,6 +37,7 @@ sidebar = dbc.Col([
         id="year-dropdown",
         options=[{"label": str(y), "value": y} for y in unique_years],
         value=unique_years[0],
+        clearable=False, 
         className="mb-3"
     ),
 
@@ -39,18 +45,23 @@ sidebar = dbc.Col([
     dcc.Dropdown(
         id="trade-type-dropdown",
         options=[{"label": trade, "value": trade} for trade in unique_trade_types],
-        value="Export",
+        value="Net trade",
+        clearable=False, 
         className="mb-3"
     ),
 
     html.Label("Goods and Services:", style={"color": TEXT_COLOR}),
     dcc.Dropdown(
         id="goods-dropdown",
-        options=[{"label": cat, "value": cat} for cat in unique_categories],
+        options=[{"label": cat, "value": cat, "title": cat, "label": truncate_text(cat, 25)} for cat in unique_categories],
         value="All sections",
-        className="mb-3"
+        clearable=False, 
+        className="mb-3",
+        style={
+        "whiteSpace": "nowrap",
+        "textOverflow": "ellipsis",
+    }
     ),
-
     html.Hr(style={"border-top": "1px solid white"}),
     html.P(
         "This Dash application provides an interactive dashboard for visualizing trade relations between Canada and the US",

--- a/src/data.py
+++ b/src/data.py
@@ -58,9 +58,9 @@ except:
 # Extract unique values for dropdown options
 unique_years = sorted(df["YEAR"].unique(), reverse=True)
 unique_provinces = ["Canada"] + sorted([geo for geo in df["GEO"].unique() if geo != "Canada"])
-unique_categories = sorted(df["CATEGORY"].dropna().unique())
+unique_categories = ["All sections"] + sorted([cat for cat in df["CATEGORY"].dropna().unique() if cat != "All sections"])
 unique_trade_types = sorted(df["TRADE"].unique())  
-
+unique_trade_types = ["Net trade"] + sorted([trade for trade in df["TRADE"].unique() if trade != "Net trade"])
 # Define color scheme
 HEADER_BG_COLOR = "#343A40"  # Dark grey for header
 SIDEBAR_BG_COLOR = "#FFFFF"


### PR DESCRIPTION
This PR introduces several improvements to the CAN-US Trade Relations Dashboard, addressing UI enhancements, bug fixes, and visual interpretability

- Text Wrapping for Filtering UI – Ensured filter dropdowns handle long text properly for better readability.
- Fixed Map Disappearing Issue for Negative Net Trade – Adjusted log transformation and color scale to ensure the map correctly displays provinces with negative net trade values.
- Set Net Trade as Default Trade Type – Now, the dashboard loads with Net Trade pre-selected.
- Set ‘All Sections’ as Default for Goods & Services – The first option in the dropdown is now All Sections to provide a more general overview by default.
- Outlined All Provinces for Better Visualization – Ensured all provinces remain visible, even when they have no trade data.
- Improved Color Scale Interpretability –
  - Exports now use a green scale for intuitive representation of positive trade.
  - Negative Net Trade uses a red scale for clearer visualization of deficits.